### PR TITLE
fix: normalize file path

### DIFF
--- a/plugin/index.js
+++ b/plugin/index.js
@@ -1,10 +1,13 @@
 import { execSync } from "child_process";
+import { relative } from "path";
 
 function filterCommits({ commits, logger }, path) {
   return commits.filter((commit) => {
     const changedFiles = getChangedFiles(commit.hash);
-    const normalizedPath = path.startsWith('./') ? path.slice(2) : path;
-    const isRelevant = changedFiles.some((file) => file.startsWith(normalizedPath));
+    const isRelevant = changedFiles.some((file) => {
+      const relativePath = relative(path, file);
+      return !relativePath.startsWith('..');
+    });
     if (!isRelevant) {
       logger.info(
         `Filtered out commit ${commit.hash.slice(


### PR DESCRIPTION
Task: [DX-1987](https://bitgoinc.atlassian.net/jira/software/c/projects/DX/boards/370?selectedIssue=DX-1987)

Context: Commits are being filtered out in [this repo](https://github.com/BitGo/risk-score-service/actions/runs/18047198253/job/51360768830) because the file path `./sdk` doesn't match with `sdk`.
<img width="999" height="188" alt="Screenshot 2025-09-30 at 2 50 26 PM" src="https://github.com/user-attachments/assets/9afed5f2-fe46-476f-9cca-7f5068744065" />
